### PR TITLE
Fix incorrectly unbound parent-map move event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,7 @@ class Minimap extends mapboxgl.NavigationControl {
 
   private onRemove() {
     this.parentMap.off('move', this.onMainMapMove);
-    this.parentMap.off('move', this.onMainMapMoveEnd);
+    this.parentMap.off('moveend', this.onMainMapMoveEnd);
 
     this.miniMap.off('load', this.onLoad);
 


### PR DESCRIPTION
If the minimap is added and removed in runtime, the moveend event is not unbound from the parent map, which leads to errors in the console and wierd behavior after the minimap is added again.